### PR TITLE
グループ単位通知でユーザーが取得できないバグを修正

### DIFF
--- a/pkg/api/core/notice/v0/user.go
+++ b/pkg/api/core/notice/v0/user.go
@@ -21,7 +21,7 @@ func userExtraction(inputUser, inputGroup, inputNOC []uint) []uint {
 		//I should implement check function
 		for _, tmpGroup := range inputGroup {
 			result := dbGroup.Get(group.ID, &core.Group{Model: gorm.Model{ID: tmpGroup}})
-			if result.Err != nil {
+			if result.Err == nil {
 				for _, tmpResultGroup := range result.Group {
 					for _, tmpUser := range tmpResultGroup.Users {
 						userArray = append(userArray, tmpUser.ID)


### PR DESCRIPTION
userExtraction関数でグループからユーザーを取得する際、エラーチェックの条件が逆になっていたため、正常にグループを取得できた場合にユーザーが追加されなかった。

- `if result.Err != nil` を `if result.Err == nil` に修正