### PR TITLE
グループ情報APIにIX接続フィールドを追加

### DIFF
--- a/pkg/api/core/group/info/interface.go
+++ b/pkg/api/core/group/info/interface.go
@@ -78,6 +78,9 @@ type Info struct {
 	ASN            uint     `json:"asn"`
 	V4             []string `json:"v4"`
 	V6             []string `json:"v6"`
+	IX             string   `json:"ix"`
+	IXPeerType     string   `json:"ix_peer_type"`
+	IXVlanID       string   `json:"ix_vlan_id"`
 	NOC            string   `json:"noc"`
 	NOCIP          string   `json:"noc_ip"`
 	TermIP         string   `json:"term_ip"`
@@ -164,9 +167,13 @@ type Service struct {
 }
 
 type Connection struct {
-	ID        uint   `json:"id"`
-	ServiceID string `json:"service_id"`
-	Open      bool   `json:"open"`
+	ID             uint   `json:"id"`
+	ServiceID      string `json:"service_id"`
+	ConnectionType string `json:"connection_type"`
+	Open           bool   `json:"open"`
+	IX             string `json:"ix"`           // 接続IX
+	IXPeerType     string `json:"ix_peer_type"` // パブリック or PI/CUG
+	IXVlanID       string `json:"ix_vlan_id"`   // VLAN-ID（PI/CUGの場合）
 }
 
 type Request struct {

--- a/pkg/api/core/group/info/v0/info.go
+++ b/pkg/api/core/group/info/v0/info.go
@@ -381,9 +381,13 @@ func Get(c *gin.Context) {
 				// Connection
 				if *tmpConnection.Enable {
 					resultConnection = append(resultConnection, info.Connection{
-						ID:        tmpConnection.ID,
-						ServiceID: serviceID,
-						Open:      *tmpConnection.Open,
+						ID:             tmpConnection.ID,
+						ServiceID:      serviceID,
+						ConnectionType: tmpConnection.ConnectionType,
+						Open:           *tmpConnection.Open,
+						IX:             tmpConnection.IX,
+						IXPeerType:     tmpConnection.IXPeerType,
+						IXVlanID:       tmpConnection.IXVlanID,
 					})
 				}
 
@@ -413,6 +417,9 @@ func Get(c *gin.Context) {
 							ASN:        asn,
 							V4:         v4,
 							V6:         v6,
+							IX:         tmpConnection.IX,
+							IXPeerType: tmpConnection.IXPeerType,
+							IXVlanID:   tmpConnection.IXVlanID,
 							Fee:        "Free",
 							NOC:        tmpConnection.BGPRouter.NOC.Name,
 							NOCIP:      tmpConnection.TunnelEndPointRouterIP.IP,


### PR DESCRIPTION
## Summary
- Info構造体にIX接続関連フィールド（IX、IXPeerType、IXVlanID）を追加
- Connection構造体にIX接続関連フィールドとConnectionTypeを追加
- Get関数でこれらのフィールドをマッピングするように修正

## Test plan
- [ ] グループ情報APIを呼び出し、IX接続フィールドが正しく返されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)